### PR TITLE
Fix conditional notifiers

### DIFF
--- a/lib/batsir/notifiers/conditional_notifier.rb
+++ b/lib/batsir/notifiers/conditional_notifier.rb
@@ -19,7 +19,7 @@ module Batsir
           if notifier_condition.condition.call(message)
             notifier = notifier_condition.notifier
             options  = notifier_condition.options
-            notifier.new(options).notify(message)
+            notifier.notify(message)
           end
         end
         message

--- a/spec/batsir/notifiers/conditional_notifier_spec.rb
+++ b/spec/batsir/notifiers/conditional_notifier_spec.rb
@@ -43,7 +43,7 @@ describe Batsir::Notifiers::ConditionalNotifier do
       notifier_class.any_instance.should_receive(:execute)
 
       conditional = Batsir::Notifiers::ConditionalNotifier.new
-      conditional.add_notifier( true_block, notifier_class )
+      conditional.add_notifier( true_block, notifier_class.new({}) )
       conditional.execute("some message")
     end
 
@@ -55,7 +55,7 @@ describe Batsir::Notifiers::ConditionalNotifier do
       notifier_class.any_instance.should_not_receive(:execute)
 
       conditional = Batsir::Notifiers::ConditionalNotifier.new
-      conditional.add_notifier( false_block, notifier_class )
+      conditional.add_notifier( false_block, notifier_class.new({}) )
       conditional.execute("some message")
     end
   end


### PR DESCRIPTION
In trying to use conditional notifiers, I noticed it was blowing up with an error similar to the following:

```
 WARN batsir: Caught NoMethodError: undefined method `new' for #<MyModule::Notifiers::TrueNotifier:0x007fdcee054920>
    /Users/dczarnecki/projects/batsir/lib/batsir/notifiers/conditional_notifier.rb:23:in `block in execute'
    /Users/dczarnecki/projects/batsir/lib/batsir/notifiers/conditional_notifier.rb:18:in `each'
    /Users/dczarnecki/projects/batsir/lib/batsir/notifiers/conditional_notifier.rb:18:in `execute'
    /Users/dczarnecki/projects/batsir/lib/batsir/notifiers/notifier.rb:24:in `notify'
    /Users/dczarnecki/projects/batsir/lib/batsir/stage_worker.rb:24:in `block in execute'
    /Users/dczarnecki/projects/batsir/lib/batsir/stage_worker.rb:23:in `each'
    /Users/dczarnecki/projects/batsir/lib/batsir/stage_worker.rb:23:in `execute'
```

I printed out the generated code and noticed the following:

```
def self.initialize_filter_queue
  @filter_queue = Batsir::FilterQueue.new
  @filter_queue.add MyModule::Filters::StatisticsFilter.new({})
  @filter_queue.add MyModule::Filters::NoopFilter.new({})
  conditional_notifier = Batsir::Notifiers::ConditionalNotifier.new
  condition = ->(message){2 > 1}
  conditional_notifier.add_notifier condition, MyModule::Notifiers::TrueNotifier.new({})
  conditional_notifier.add_transformer Batsir::Transformers::JSONOutputTransformer.new
  @filter_queue.add_notifier conditional_notifier
end
```

So the generated code is already instantiating an instance of the notifier class to the `add_notifier` method. 
- The `ConditionalNotifierDeclaration#compile` method instantiates
  an instance of the notifier, so do not try and `new` the
  instance again.
- Update specs to reflect what the `ConditionalNotifierDeclaration#compile`
  method is doing behind the scenes.
